### PR TITLE
Remove turbo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,6 @@ gem 'puma', '~> 5.0'
 gem 'rails', '~> 7.0.1'
 gem 'sprockets-rails'
 gem 'sqlite3', '~> 1.4'
-gem 'stimulus-rails'
-gem 'turbo-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,14 +243,9 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
-    stimulus-rails (1.0.2)
-      railties (>= 6.0.0)
     strscan (3.0.1)
     thor (1.2.1)
     timeout (0.2.0)
-    turbo-rails (1.0.1)
-      actionpack (>= 6.0.0)
-      railties (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
@@ -292,8 +287,6 @@ DEPENDENCIES
   shoulda-matchers (~> 5.1)
   sprockets-rails
   sqlite3 (~> 1.4)
-  stimulus-rails
-  turbo-rails
   tzinfo-data
   web-console
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,4 +1,3 @@
-import '@hotwired/turbo-rails';
 // import "./controllers";
 
 import { initAll } from 'govuk-frontend';

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,8 +16,8 @@
     <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
     <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
 
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <%= stylesheet_link_tag "application" %>
+    <%= javascript_include_tag "application", defer: true %>
   </head>
 
   <body class="govuk-template__body">

--- a/package.json
+++ b/package.json
@@ -2,8 +2,6 @@
   "name": "app",
   "private": "true",
   "dependencies": {
-    "@hotwired/stimulus": "^3.0.1",
-    "@hotwired/turbo-rails": "^7.1.0",
     "esbuild": "^0.14.11",
     "govuk-frontend": "^4.0.0",
     "sass": "^1.47.0"


### PR DESCRIPTION
We aren't using Turbo for anything yet. Removing it so that we can
explicitly add it in the future when we're able to define why.
