### PR TITLE
Linting and test improvements

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,6 +18,7 @@
 LICENCE
 Procfile
 Procfile.*
+app/assets/builds
 bin/dev
 db/*.sqlite3
 tmp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,10 @@ inherit_gem:
 
 require:
   - rubocop-rails
+  - rubocop-rspec
 
 AllCops:
   NewCops: enable
+
+Style/Documentation:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
+  gem 'rubocop-rspec', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,6 +233,8 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
+    rubocop-rspec (2.8.0)
+      rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
@@ -286,6 +288,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-rails
+  rubocop-rspec
   shoulda-matchers (~> 5.1)
   sprockets-rails
   sqlite3 (~> 1.4)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ Run the application on `http://localhost:3000`:
 bin/dev
 ```
 
+To run the linters:
+
+```bash
+bin/lint
+```
+
+To run the tests (requires Chrome due to
+[cuprite](https://github.com/rubycdp/cuprite)):
+
+```bash
+bin/test
+```
+
 ## Licence
 
 [MIT Licence](LICENCE).

--- a/adr/00002-use-gov-paas.md
+++ b/adr/00002-use-gov-paas.md
@@ -16,7 +16,7 @@ We will use the GOV PaaS platform to host the Find My TRN web application
 
 ## Consequences
 
-* Cloud services are limited to that which are available on the GOV PaaS Platform
-* Cloudfoundry to be used to operate platform
-* AWS Shield ingress protection
-* 24/7 Support available
+- Cloud services are limited to that which are available on the GOV PaaS Platform
+- Cloudfoundry to be used to operate platform
+- AWS Shield ingress protection
+- 24/7 Support available

--- a/bin/lint
+++ b/bin/lint
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/bin/sh
 
-system("bundle exec rbprettier --write --ignore-unknown --loglevel warn '**/*'")
-system('bundle exec rubocop -A')
+bundle exec rbprettier --write --ignore-unknown --loglevel warn '**/*'
+bundle exec rubocop -A

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+system('bundle exec rspec --format documentation')

--- a/bin/test
+++ b/bin/test
@@ -1,3 +1,3 @@
-#!/usr/bin/env ruby
+#!/bin/sh
 
-system('bundle exec rspec --format documentation')
+bundle exec rspec --format documentation

--- a/spec/system/homes_spec.rb
+++ b/spec/system/homes_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Home', type: :system do
-  scenario 'visiting the home page' do
+  it 'visiting the home page' do
     visit_home_page
     expect_to_see_home_page
   end


### PR DESCRIPTION
- Add rubocop-rspec and autofix suggestions
- Disable Style/Documentation rule
- Fixup ADR using prettier
- Don't run prettier on compiled JS/CSS
- Add and document bin/test script
- Use /bin/sh instead of ruby to run lint and test scripts 