### PR TITLE
Add docker image package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,15 @@ on:
     branches:
       - '**'
 
+env:
+  CONTAINER_REGISTRY: ghcr.io
+
 jobs:
   rspec:
-    name: Rspec
+    name: Build & Test
     runs-on: ubuntu-20.04
+    outputs:
+      docker_image: ${{ steps.image.outputs.tag }}
 
     steps:
       - name: Checkout code
@@ -22,3 +27,22 @@ jobs:
 
       - name: Run tests
         run: bundle exec rspec --format documentation
+
+      - name: Docker image tag
+        id: image
+        run: |
+          echo ::set-output name=tag::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):$GITHUB_SHA
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.CONTAINER_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker build & push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.image.outputs.tag }}


### PR DESCRIPTION
## Context
The app can be deployed as a docker container to PaaS environments.
This requires a Docker image to be built and pushed to Github packages.
This PR adds steps to build and push the container image.

## Trello card

https://trello.com/c/Uxm2n5Zh