### PR TITLE
Update Ruby in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.0-alpine
+FROM ruby:3.0.3-alpine
 RUN apk add gcc git libc6-compat libc-dev make nodejs sqlite-dev tzdata yarn
 
 WORKDIR /myapp


### PR DESCRIPTION
In #14, the Ruby version was downgraded to 3.0.3 for compatibility with
the deployment platform.

I missed updating the Dockerfile during this change.
