### PR TITLE
Add an environment to the deployment action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   deploy:
-    name: Deploy
+    environment: dev
+    name: Deploy (dev)
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
We are using the [environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) feature of GitHub Actions.

This allows us to set secrets on a per environment basis.

In order to use this, We need to specify the environment for an
action to run in.
