### PR TITLE
Add a markdown renderer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ ruby '3.0.3'
 gem 'bootsnap', require: false
 gem 'govuk-components'
 gem 'govuk_design_system_formbuilder'
+gem 'govuk_markdown', '~> 1.0'
 gem 'importmap-rails'
 gem 'logstop', '~> 0.2.8'
 gem 'puma', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,9 @@ GEM
       activemodel (>= 6.1)
       activesupport (>= 6.1)
       deep_merge (~> 1.2.1)
+    govuk_markdown (1.0.0)
+      activesupport
+      redcarpet
     i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.0.2)
@@ -192,6 +195,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redcarpet (3.5.1)
     regexp_parser (2.2.0)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -278,6 +282,7 @@ DEPENDENCIES
   foreman (~> 0.87.2)
   govuk-components
   govuk_design_system_formbuilder
+  govuk_markdown (~> 1.0)
   importmap-rails
   logstop (~> 0.2.8)
   prettier (~> 2.0)

--- a/app/views/pages/_header.html.md
+++ b/app/views/pages/_header.html.md
@@ -1,0 +1,3 @@
+### Find My TRN
+
+Your _application_ is **ready** - so long as this page rendered without any errors you're good to go.

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,10 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Find My TRN</h1>
-
-    <p class="govuk-body">
-      Your application is ready - so long as this page rendered without any errors you're good to go.
-    </p>
+    <%= render 'header' %>
 
     <%= govuk_summary_list(
       rows: [

--- a/config/initializers/govuk_markdown.rb
+++ b/config/initializers/govuk_markdown.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class MarkdownTemplate
+  def self.call(template, source)
+    compiled = GovukMarkdown.render(source)
+    erb_handler.call(template, compiled)
+  end
+
+  def self.erb_handler
+    ActionView::Template.registered_template_handler(:erb)
+  end
+end
+
+ActionView::Template.register_template_handler :md, MarkdownTemplate


### PR DESCRIPTION
We want to add the ability to render markdown templates to make it
easier for people to add and format copy.

There is a DfE-Digital library for a GOVUK styled markdown renderer,
called [GovukMarkdown](https://github.com/DFE-Digital/govuk_markdown).

I opted to register this as a Rails template handler to make it simple
for someone to add a markdown partial and include it in a view template.

The other option I considered was to write a helper method that we could
include in the erb templates that would convert a markdown string into
HTML. Ultimately, this seemed like it would end up with code that was
harder to read.

I think the separation of markdown and HTML makes the most sense from a
developer experience point of view.
