### PR TITLE
Minor tooling updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,6 @@ AllCops:
 
 Style/Documentation:
   Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-ruby 3.1.0
+ruby 3.0.3
 nodejs 16.13.2
 yarn 1.22.17


### PR DESCRIPTION
Disable an annoying Rubocop rule and update the Ruby version in `.tool-versions`